### PR TITLE
fix: finalCurrentIndex gets out of range

### DIFF
--- a/Sources/CardStack/CardStack.swift
+++ b/Sources/CardStack/CardStack.swift
@@ -73,7 +73,7 @@ public struct CardStack<Data, Content>: View where Data: RandomAccessCollection,
         } else {
             self.currentIndex = index
         }
-        self.finalCurrentIndex = Int(index)
+        self.finalCurrentIndex = Int(self.currentIndex)
     }
     
     private func zIndex(for index: Int) -> Double {


### PR DESCRIPTION
Issue:
- The finalCurrentIndex goes out of range when dragging left on the first card or dragging right on the last card. This results in finalCurrentIndex taking values of -1 or data.count, causing errors in other use cases.

Solution:
- Modify self.currentIndex to be equal to Int(currentIndex) instead of Int(index).

Outcome:
- All behaviors remain the same, and the bug is resolved.